### PR TITLE
Narrow scope of test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "supertest": "^1.2"
   },
   "scripts": {
-    "test": "eslint . && mocha"
+    "test": "eslint api frontend test/unit test/integration && mocha --recursive"
   },
   "engines": {
     "node": ">= 4.0.0"


### PR DESCRIPTION
Apply eslint only to the api, frontend and test directories and allow
mocha to recurse through the tests so we can verify everything conforms
to the chosen style guide and all tests pass.

Signed-off-by: Ryan Y <ryayak1460@protingumas.com>