### PR TITLE
Remove global object from tests

### DIFF
--- a/test/integration/controllers/AuthController.test.js
+++ b/test/integration/controllers/AuthController.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('AuthController', () => {
     it('should exist', () => {
-        assert(global.app.api.controllers['AuthController']);
+        assert(app.api.controllers['AuthController']);
     });
 });

--- a/test/integration/controllers/CategoryController.test.js
+++ b/test/integration/controllers/CategoryController.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const assert = require('assert')
+const app = require('../../../index');
 
 describe('CategoryController', () => {
   it('should exist', () => {
-    assert(global.app.controllers.CategoryController)
+    assert(app.api.controllers.CategoryController)
   })
 })

--- a/test/integration/controllers/UserController.test.js
+++ b/test/integration/controllers/UserController.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('UserController', () => {
     it('should exist', () => {
-        assert(global.app.api.controllers['UserController']);
+        assert(app.api.controllers['UserController']);
     });
 });

--- a/test/integration/policies/Auth.test.js
+++ b/test/integration/policies/Auth.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Auth', () => {
     it('should exist', () => {
-        assert(global.app.api.policies['Auth']);
+        assert(app.api.policies['Auth']);
     });
 });

--- a/test/unit/models/Candidate.test.js
+++ b/test/unit/models/Candidate.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Candidate Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Candidate']);
+        assert(app.api.models['Candidate']);
     });
 });

--- a/test/unit/models/Category.test.js
+++ b/test/unit/models/Category.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const assert = require('assert')
+const app = require('../../../index');
 
 describe('Category Model', () => {
   it('should exist', () => {
-    assert(global.app.models.Category)
+    assert(app.api.models.Category)
   })
 })

--- a/test/unit/models/Office.test.js
+++ b/test/unit/models/Office.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Office Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Office']);
+        assert(app.api.models['Office']);
     });
 });

--- a/test/unit/models/Question.test.js
+++ b/test/unit/models/Question.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Question Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Question']);
+        assert(app.api.models['Question']);
     });
 });

--- a/test/unit/models/Region.test.js
+++ b/test/unit/models/Region.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Region Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Region']);
+        assert(app.api.models['Region']);
     });
 });

--- a/test/unit/models/Role.test.js
+++ b/test/unit/models/Role.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Role Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Role']);
+        assert(app.api.models['Role']);
     });
 });

--- a/test/unit/models/Survey.test.js
+++ b/test/unit/models/Survey.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('Survey Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['Survey']);
+        assert(app.api.models['Survey']);
     });
 });

--- a/test/unit/models/SurveyResult.test.js
+++ b/test/unit/models/SurveyResult.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('SurveyResult Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['SurveyResult']);
+        assert(app.api.models['SurveyResult']);
     });
 });

--- a/test/unit/models/SurveyResultAnswer.test.js
+++ b/test/unit/models/SurveyResultAnswer.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('SurveyResultAnswer Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['SurveyResultAnswer']);
+        assert(app.api.models['SurveyResultAnswer']);
     });
 });

--- a/test/unit/models/SurveyResultCategory.test.js
+++ b/test/unit/models/SurveyResultCategory.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const assert = require('assert')
+const app = require('../../../index');
 
 describe('SurveyResultCategory Model', () => {
   it('should exist', () => {
-    assert(global.app.models.SurveyResultCategory)
+    assert(app.api.models.SurveyResultCategory)
   })
 })

--- a/test/unit/models/User.test.js
+++ b/test/unit/models/User.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('User Model', () => {
     it('should exist', () => {
-        assert(global.app.api.models['User']);
+        assert(app.api.models['User']);
     });
 });

--- a/test/unit/services/AuthService.test.js
+++ b/test/unit/services/AuthService.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('AuthService', () => {
     it('should exist', () => {
-        assert(global.app.api.services['AuthService']);
+        assert(app.api.services['AuthService']);
     });
 });

--- a/test/unit/services/CategoryService.test.js
+++ b/test/unit/services/CategoryService.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const assert = require('assert')
+const app = require('../../../index');
 
 describe('CategoryService', () => {
   it('should exist', () => {
-    assert(global.app.services.CategoryService)
+    assert(app.api.services.CategoryService)
   })
 })

--- a/test/unit/services/UserService.test.js
+++ b/test/unit/services/UserService.test.js
@@ -2,9 +2,10 @@
 /* global describe, it */
 
 const assert = require('assert');
+const app = require('../../../index');
 
 describe('UserService', () => {
     it('should exist', () => {
-        assert(global.app.api.services['UserService']);
+        assert(app.api.services['UserService']);
     });
 });


### PR DESCRIPTION
Remove the global object from tests so we can run them locally without
any particular setup.

Signed-off-by: Ryan Y <ryayak1460@protingumas.com>