### PR TITLE
Split frontend watch task into three.

### DIFF
--- a/config/gulp.js
+++ b/config/gulp.js
@@ -1,103 +1,117 @@
-'use strict'
+'use strict';
 
-const gulp = require('gulp')
-const babel = require('gulp-babel')
-const sass = require('gulp-sass')
-const webpack = require('webpack-stream')
-const watch = require('gulp-watch')
-const path = require('path')
+const gulp = require('gulp');
+const babel = require('gulp-babel');
+const sass = require('gulp-sass');
+const webpack = require('webpack-stream');
+const path = require('path');
 
 const babelConfig = {
-  presets: ['react', 'es2015'],
-  plugins: [
-    [
-      'css-modules-transform', {
-        preprocessCss: 'preprocessor.js',
-        generateScopedName: '[name]__[local]___[hash:base64:5]',
-        extensions: ['.css', '.scss'],
-        extractCss: './dist/styles/production.css'
-      }
+    presets: ['react', 'es2015'],
+    plugins: [
+        [
+            'css-modules-transform', {
+                preprocessCss: 'preprocessor.js',
+                generateScopedName: '[name]__[local]___[hash:base64:5]',
+                extensions: ['.css', '.scss'],
+                extractCss: './dist/styles/production.css'
+            }
+        ]
     ]
-  ]
-}
+};
 
 module.exports = {
 
-  defaultTaskName: 'default',
+    defaultTaskName: 'default',
 
-  tasks: {
+    tasks: {
 
-    default: ['compileTemplate', 'compileStyles', 'moveImages', 'bundleAdmin', 'bundleClient', 'watch'],
+        default: ['compileTemplate', 'compileStyles', 'moveImages', 'bundleAdmin', 'bundleClient', 'watchTemplates', 'watchStyles', 'watchImages'],
 
-    watch: () => {
-      return gulp.watch(
-        path.join('frontend', '**', '*'),
-        ['compileTemplate', 'compileStyles', 'moveImages', 'bundleAdmin', 'bundleClient'])
-    },
+        watchTemplates: () => {
+            return gulp.watch(
+                path.join('frontend', 'js', '**', '*'),
+                ['compileTemplate', 'bundleAdmin', 'bundleClient']
+            );
+        },
 
-    compileTemplate: () => {
-      return gulp.src('./frontend/js/**/*.js')
-        .pipe(babel(babelConfig))
-        .pipe(gulp.dest('dist'))
-    },
+        watchStyles: () => {
+            return gulp.watch(
+                path.join('frontend', 'styles', '**', '*'),
+                ['compileStyles']
+            );
+        },
 
-    compileStyles: () => {
-      return gulp.src('./frontend/styles/**/*.scss')
-        .pipe(sass({includePaths: [ 'node_modules' ]})
-        .on('error', sass.logError))
-        .pipe(gulp.dest('dist/styles'))
-    },
+        watchImages: () => {
+            return gulp.watch(
+                path.join('frontend', 'images', '**', '*'),
+                ['moveImages']
+            );
+        },
 
-    moveImages: () => {
-      return gulp.src('./frontend/images/**/*.*')
-      .pipe(gulp.dest('dist/images'))
-    },
+        compileTemplate: () => {
+            return gulp.src('./frontend/js/**/*.js')
+                .pipe(babel(babelConfig))
+                .pipe(gulp.dest('dist'));
+        },
 
-    bundleAdmin: () => {
-      return gulp.src('frontend/js/components/admin-bundle.js')
-        .pipe(webpack({
-          output: {
-            filename: 'admin-bundle.js'
-          },
-          module: {
-            loaders: [{
-              test: /\.js$/,
-              loader: 'babel-loader',
-              query: {
-                presets: ['react', 'es2015']
-              }
-            },
-            {
-              test: /\.(css|scss)$/,
-              loaders: ['style', 'css', 'sass']
-            }]
-          }
-        }))
-        .pipe(gulp.dest('dist'))
-    },
+        compileStyles: () => {
+            return gulp.src('./frontend/styles/**/*.scss')
+                .pipe(sass({ includePaths: ['node_modules'] })
+                    .on('error', sass.logError))
+                .pipe(gulp.dest('dist/styles'));
+        },
 
-    bundleClient: () => {
-      return gulp.src('frontend/js/components/client-bundle.js')
-        .pipe(webpack({
-          output: {
-            filename: 'client-bundle.js'
-          },
-          module: {
-            loaders: [{
-              test: /\.js$/,
-              loader: 'babel-loader',
-              query: {
-                presets: ['react', 'es2015']
-              }
-            },
-            {
-              test: /\.(css|scss)$/,
-              loaders: ['style', 'css', 'sass']
-            }]
-          }
-        }))
-        .pipe(gulp.dest('dist'))
+        moveImages: () => {
+            return gulp.src('./frontend/images/**/*.*')
+                .pipe(gulp.dest('dist/images'));
+        },
+
+        bundleAdmin: () => {
+            return gulp.src('frontend/js/components/admin-bundle.js')
+                .pipe(webpack({
+                    output: {
+                        filename: 'admin-bundle.js'
+                    },
+                    module: {
+                        loaders: [{
+                            test: /\.js$/,
+                            loader: 'babel-loader',
+                            query: {
+                                presets: ['react', 'es2015']
+                            }
+                        },
+                        {
+                            test: /\.(css|scss)$/,
+                            loaders: ['style', 'css', 'sass']
+                        }]
+                    }
+                }))
+                .pipe(gulp.dest('dist'));
+        },
+
+        bundleClient: () => {
+            return gulp.src('frontend/js/components/client-bundle.js')
+                .pipe(webpack({
+                    output: {
+                        filename: 'client-bundle.js'
+                    },
+                    module: {
+                        loaders: [{
+                            test: /\.js$/,
+                            loader: 'babel-loader',
+                            query: {
+                                presets: ['react', 'es2015']
+                            }
+                        },
+                        {
+                            test: /\.(css|scss)$/,
+                            loaders: ['style', 'css', 'sass']
+                        }]
+                    }
+                }))
+                .pipe(gulp.dest('dist'));
+        }
     }
-  }
 
-}
+};


### PR DESCRIPTION
lint config/gulp.js

This is intended to reduce the amount of time it takes for changes introduced by a frontend developer to be reflected in the app being served by Trails.