### PR TITLE
node_modules is in a different location when using docker.  Add '../n…

### DIFF
--- a/config/gulp.js
+++ b/config/gulp.js
@@ -57,8 +57,12 @@ module.exports = {
 
         compileStyles: () => {
             return gulp.src('./frontend/styles/**/*.scss')
-                .pipe(sass({ includePaths: ['node_modules'] })
-                    .on('error', sass.logError))
+                .pipe(sass({
+                    includePaths: [
+                        'node_modules',
+                        '../node_modules'
+                    ]}))
+                    .on('error', sass.logError)
                 .pipe(gulp.dest('dist/styles'));
         },
 


### PR DESCRIPTION
…ode_modules' as a place for sass to look for modules.