### PR TITLE
fix PG sequence values when manually setting IDs

### DIFF
--- a/config/dev-fixtures/question-fixtures.js
+++ b/config/dev-fixtures/question-fixtures.js
@@ -63,7 +63,15 @@ module.exports = {
                 questions.map(question => {
                     return app.orm.Question.create(question);
                 })
-            );
+            )
+            .then(questions => {
+
+                const maxId = Math.max.apply(Math,questions.map(function(o){return o.id;}));
+                app.orm.Question.sequelize.query('select setval(\'question_id_seq\', ' + maxId + ')');
+
+                app.log.info('Questions created');
+                return questions;
+            });
         });
     }
 };

--- a/config/dev-fixtures/survey-fixtures.js
+++ b/config/dev-fixtures/survey-fixtures.js
@@ -37,6 +37,10 @@ module.exports = {
             );
         })
         .then(surveys => {
+
+            const maxId = Math.max.apply(Math,surveys.map(function(o){return o.id;}));
+            app.orm.Survey.sequelize.query('select setval(\'survey_id_seq\', ' + maxId + ')');
+
             app.log.info('Surveys created');
             return surveys;
         });

--- a/config/dev-fixtures/survey-result-fixtures.js
+++ b/config/dev-fixtures/survey-result-fixtures.js
@@ -61,7 +61,15 @@ module.exports = {
                     surveyResults.map(surveyResult => {
                         return app.orm.SurveyResult.create(surveyResult);
                     })
-                );
+                )
+                .then(surveyResults => {
+
+                    const maxId = Math.max.apply(Math,surveyResults.map(function(o){return o.id;}));
+                    app.orm.SurveyResult.sequelize.query('select setval(\'surveyresult_id_seq\', ' + maxId + ')');
+
+                    app.log.info('Survey results created');
+                    return surveyResults;
+                });
             }
         });
     }


### PR DESCRIPTION
Postgres sequences do not have their current value set correctly when manually specifying ID. Call a separate function to set them in the fixture data when a manual ID is required.