### PR TITLE
Move sequence fix earlier to prevent errors on app restart

### DIFF
--- a/config/dev-fixtures/question-fixtures.js
+++ b/config/dev-fixtures/question-fixtures.js
@@ -58,6 +58,10 @@ module.exports = {
             if (count > 0) {
                 return [];
             }
+
+            const maxId = Math.max.apply(Math,questions.map(function(o){return o.id;}));
+            app.orm.Question.sequelize.query('select setval(\'question_id_seq\', ' + maxId + ')');
+
             // Create questions.
             return Promise.all(
                 questions.map(question => {
@@ -65,9 +69,6 @@ module.exports = {
                 })
             )
             .then(questions => {
-
-                const maxId = Math.max.apply(Math,questions.map(function(o){return o.id;}));
-                app.orm.Question.sequelize.query('select setval(\'question_id_seq\', ' + maxId + ')');
 
                 app.log.info('Questions created');
                 return questions;

--- a/config/dev-fixtures/survey-fixtures.js
+++ b/config/dev-fixtures/survey-fixtures.js
@@ -29,6 +29,10 @@ module.exports = {
             if (count > 0) {
                 return [];
             }
+            
+            const maxId = Math.max.apply(Math,surveys.map(function(o){return o.id;}));
+            app.orm.Survey.sequelize.query('select setval(\'survey_id_seq\', ' + maxId + ')');
+
             // Create surveys.
             return Promise.all(
               surveys.map(survey => {
@@ -37,10 +41,6 @@ module.exports = {
             );
         })
         .then(surveys => {
-
-            const maxId = Math.max.apply(Math,surveys.map(function(o){return o.id;}));
-            app.orm.Survey.sequelize.query('select setval(\'survey_id_seq\', ' + maxId + ')');
-
             app.log.info('Surveys created');
             return surveys;
         });

--- a/config/dev-fixtures/survey-result-fixtures.js
+++ b/config/dev-fixtures/survey-result-fixtures.js
@@ -55,22 +55,21 @@ module.exports = {
             if (count > 0) {
                 return [];
             }
-            else {
-                // Create survey results
-                return Promise.all(
-                    surveyResults.map(surveyResult => {
-                        return app.orm.SurveyResult.create(surveyResult);
-                    })
-                )
-                .then(surveyResults => {
 
-                    const maxId = Math.max.apply(Math,surveyResults.map(function(o){return o.id;}));
-                    app.orm.SurveyResult.sequelize.query('select setval(\'surveyresult_id_seq\', ' + maxId + ')');
+            const maxId = Math.max.apply(Math,surveyResults.map(function(o){return o.id;}));
+            app.orm.SurveyResult.sequelize.query('select setval(\'surveyresult_id_seq\', ' + maxId + ')');
 
-                    app.log.info('Survey results created');
-                    return surveyResults;
-                });
-            }
+            // Create survey results
+            return Promise.all(
+                surveyResults.map(surveyResult => {
+                    return app.orm.SurveyResult.create(surveyResult);
+                })
+            )
+            .then(surveyResults => {
+
+                app.log.info('Survey results created');
+                return surveyResults;
+            });
         });
     }
 };


### PR DESCRIPTION
Fixes an error caused by the sequence fix code firing when the fixture data is already loaded.