### PR TITLE
Consider voter response records to be pristine.

### DIFF
--- a/frontend/js/components/environments/Survey.js
+++ b/frontend/js/components/environments/Survey.js
@@ -65,14 +65,19 @@ class Survey extends Component {
                 )
             );
         }
-        return this.props.dispatch(
-            updateSurveyResultAnswer(
-                answer.id,
-                answer,
-                sentiment,
-                callback
-            )
-        );
+        // Check to see if the user modified their answer before resubmitting.
+        else if (!answer.pristine) {
+            return this.props.dispatch(
+                updateSurveyResultAnswer(
+                    answer.id,
+                    answer,
+                    sentiment,
+                    callback
+                )
+            );
+        }
+        // Otherwise, continue without making changes.
+        return callback();
     }
 
     getQuestionAndResponses() {

--- a/frontend/js/redux/actions/survey-actions.js
+++ b/frontend/js/redux/actions/survey-actions.js
@@ -248,10 +248,10 @@ export function updateSurveyResultAnswerRequest() {
     };
 }
 
-export function updateSurveyResultAnswerSuccess(response) {
+export function updateSurveyResultAnswerSuccess(QuestionId) {
     return {
         type: UPDATE_SURVEY_RESULT_ANSWER_SUCCESS,
-        response
+        QuestionId
     };
 }
 
@@ -278,8 +278,8 @@ export function updateSurveyResultAnswer(id, answer, sentiment, callback) {
             .then(checkStatus)
             .then(response => response.json())
             .then(response => {
-                dispatch(updateSurveyResultAnswerSuccess(response));
-                callback(null, response);
+                dispatch(updateSurveyResultAnswerSuccess(answer.QuestionId));
+                callback(null);
             })
             .catch(error => {
                 dispatch(updateSurveyResultAnswerFailure(error));

--- a/frontend/js/redux/actions/survey-actions.js
+++ b/frontend/js/redux/actions/survey-actions.js
@@ -295,7 +295,7 @@ export function updateSurveyResultAnswer(response, callback) {
             .then(checkStatus)
             .then(response => response.json())
             .then(response => {
-                dispatch(updateSurveyResultAnswerSuccess(answer.QuestionId));
+                dispatch(updateSurveyResultAnswerSuccess(response.QuestionId));
                 callback(null);
             })
             .catch(error => {

--- a/frontend/js/redux/reducers/survey-reducer.js
+++ b/frontend/js/redux/reducers/survey-reducer.js
@@ -10,7 +10,8 @@ import {
     SET_SURVEY_FORMAT,
     FETCH_SURVEY_RESULT_SUCCESS,
     CREATE_SURVEY_RESULT_SUCCESS,
-    CREATE_SURVEY_RESULT_ANSWER_SUCCESS
+    CREATE_SURVEY_RESULT_ANSWER_SUCCESS,
+    UPDATE_SURVEY_RESULT_ANSWER_SUCCESS
 } from './../actions/survey-actions';
 
 const initialState = {
@@ -52,7 +53,8 @@ export default function surveyReducer(state = initialState, action) {
         obj[action.questionId] = Object.assign(
             {},
             state.answers[action.questionId], {
-                sentiment: action.sentiment
+                sentiment: action.sentiment,
+                pristine: false
             }
         );
 
@@ -64,7 +66,8 @@ export default function surveyReducer(state = initialState, action) {
         obj[action.questionId] = Object.assign(
             {},
             state.answers[action.questionId], {
-                AnswerId: action.answerId
+                AnswerId: action.answerId,
+                pristine: false
             }
         );
 
@@ -100,6 +103,7 @@ export default function surveyReducer(state = initialState, action) {
             publicPassPhrase: action.response.publicPassPhrase,
             answers: action.response.SurveyResultAnswers
                 .reduce((memo, value) => {
+                    value['pristine'] = true;
                     memo[value.QuestionId] = value;
                     return memo;
                 }, {})
@@ -107,6 +111,19 @@ export default function surveyReducer(state = initialState, action) {
 
     case CREATE_SURVEY_RESULT_ANSWER_SUCCESS:
         obj[action.response.QuestionId] = action.response;
+        obj[action.response.QuestionId].pristine = true;
+
+        return Object.assign({}, state, {
+            answers: Object.assign({}, state.answers, obj)
+        });
+
+    case UPDATE_SURVEY_RESULT_ANSWER_SUCCESS:
+        obj[action.QuestionId] = Object.assign(
+            {},
+            state.answers[action.QuestionId],
+            {pristine: true}
+        );
+
         return Object.assign({}, state, {
             answers: Object.assign({}, state.answers, obj)
         });


### PR DESCRIPTION
If they are pristine, don't resubmit.
If user has changed their response, update the appropriate record.

Blocked by #202