### PR TITLE
Have gulpfile build out tasks based on contents of gulp config file, …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const gulp = require('gulp');
+const { tasks } = require('./config/gulp');
+const compileTasks = tasks.default.filter(task => {
+    return !task.includes('watch');
+});
+
+compileTasks.forEach(task => {
+    gulp.task(task, tasks[task]);
+});
+
+gulp.task('default', compileTasks);

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   },
   "scripts": {
     "acceptance": "cucumberjs",
-    "test": "eslint api frontend test/unit test/integration && mocha --recursive"
+    "test": "eslint api frontend test/unit test/integration && mocha --recursive",
+    "gulp": "gulp"
   },
   "engines": {
     "node": ">= 4.0.0"


### PR DESCRIPTION
…ignoring watch tasks.

This is helpful for CI, where we need to confirm that compiled assets are available before running tests.

In Codeship, Project Test Settings,
`npm rebuild && npm test` should become `npm rebuild && gulp && npm test`