### PR TITLE
Tweak question counts

### DIFF
--- a/api/services/SurveyResultService.js
+++ b/api/services/SurveyResultService.js
@@ -98,6 +98,13 @@ module.exports = class SurveyResultService extends Service {
                             (v.CandidateSentiment + v.SurveyResultSentiment) / 10 :
                             v.SurveyResultSentiment / 5);
 
+                    const numQuestions = v.sentiment ? (
+                        v.multipleChoice ? (
+                            v.AnswerId == v.CandidateAnswerId ?
+                            1 : 0
+                        ) : 1
+                    ) : 1;
+
                     const candidate = {
                         name: v.Name,
                         office: v.Office,
@@ -106,13 +113,13 @@ module.exports = class SurveyResultService extends Service {
                         url: v.url,
                         infoUrl: v.infoUrl,
                         score: score,
-                        numQuestions: 1,
+                        numQuestions: numQuestions,
                         categories: []
                     };
 
                     const category = {
                         categoryName: v.CategoryName,
-                        numQuestions: 1,
+                        numQuestions: numQuestions,
                         score: score
                     };
 

--- a/api/services/SurveyResultService.js
+++ b/api/services/SurveyResultService.js
@@ -90,8 +90,8 @@ module.exports = class SurveyResultService extends Service {
                         v.AnswerId == v.CandidateAnswerId ? (
                             v.sentiment ? (
                                 v.CandidateSentiment > 0 ?
-                                    (v.CandidateSentiment + v.SurveyResultSentiment) / 10 :
-                                    v.SurveyResultSentiment / 5
+                                    1 + ((v.CandidateSentiment + v.SurveyResultSentiment) / 10) :
+                                    1 + (v.SurveyResultSentiment / 5)
                             ) : 1
                         ) : 0
                     ) : (v.CandidateSentiment != null ?
@@ -99,10 +99,7 @@ module.exports = class SurveyResultService extends Service {
                             v.SurveyResultSentiment / 5);
 
                     const numQuestions = v.sentiment ? (
-                        v.multipleChoice ? (
-                            v.AnswerId == v.CandidateAnswerId ?
-                            1 : 0
-                        ) : 1
+                        v.multipleChoice ? 2 : 1
                     ) : 1;
 
                     const candidate = {


### PR DESCRIPTION
Count `numQuestions` differently depending on whether the survey uses intensity or not. If the survey uses intensity and is multiple choice only count questions where `AnswerId == CandidateAnswerId`. Otherwise count all questions.