### PR TITLE
Gulp docker fix plus plus

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
 # add git-ignore syntax here of things you don't want copied into docker image
 
-.git
-*Dockerfile*
+coverage
+dist
 *docker-compose*
+*Dockerfile*
+.DS_STORE
+env_vars
+.git
 node_modules
+npm-debug.log
+.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ENV NODE_PATH=/usr/src/node_modules
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 
+# do last minute things on the code
+RUN npm run gulp 
+
 # if you want to use npm start instead, then use `docker run --init in production`
 # so that signals are passed properly. Note the code in index.js is needed to catch Docker signals
 # using node here is still more graceful stopping then npm with --init afaik

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       context: .
       args:
         NODE_ENV: development
-    entrypoint: /usr/src/app/docker/docker-entrypoint.sh 
+    # special startup script just for local development
+    entrypoint: /usr/src/app/docker/docker-entrypoint-dev.sh 
     command: ../node_modules/.bin/nodemon server.js --inspect=0.0.0.0:9229
     environment:
       NODE_ENV: development
@@ -19,7 +20,9 @@ services:
       OKC_SESSION_SECRET_KEY: someGobbledygookThatIsAtLeast32CharactersLong
       GOOGLE_API_KEY: google_api_key
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/app:delegated
+        # for local dev only, we "hide" host-based node_modules so they don't conflict
+      - notused:/usr/src/app/node_modules
     ports:
       - "80:3000"
       - "9229:9229"
@@ -33,4 +36,5 @@ services:
     ports:
       - "5432:5432"
 
-
+volumes:
+  notused:

--- a/docker/docker-entrypoint-dev.sh
+++ b/docker/docker-entrypoint-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# do last minute things just for local dev
+npm run gulp
+
+exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-# remove node_modules as a subdir, even if bind-mounted from host
-# the correct node_modules was installed under /usr/src/node_modules
-rm -rf /usr/src/app/node_modules
-
-exec "$@"


### PR DESCRIPTION
- gulp now runs on image build after copying the source code into the image
- gulp also runs in compose file entrypoint script for local development where we have to bind-mount host source code over top of image source code.
- rather than delete host node_modules when compose bind-mounts for local development, it now just overlays app/node_modules with an empty volume so host copy isn't seen inside the container.
- added more files and subdirs to dockerignore to make the image smaller
